### PR TITLE
Automate catalog publishing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -382,7 +382,7 @@ gulp.task('push-config-and-catalog', function() {
     runCmd('git', ['commit', '-m', 'Update initialization URL'], true);
     runCmd('git', ['push', 'origin', '_testing'], true);
     const date=releaseLabel();
-    runCmd('gitz', ['tag', '-a', `${DATE}`, '-m', `${date} release`], true);
+    runCmd('git', ['tag', '-a', `${date}`, '-m', `${date} release`], true);
 });
 
 gulp.task('release-catalog', ['build-catalog', 'publish-catalog', 'update-init-url', 'push-config-and-catalog']);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.3",
     "semver": "^5.0.0",
+    "shelljs": "^0.8.3",
     "style-loader": "^0.19.1",
     "svg-sprite-loader": "^3.4.0",
     "sync-request": "^6.0.0",
@@ -82,7 +83,8 @@
     "deploy": "rm -rf node_modules && npm install && npm run deploy-without-reinstall",
     "deploy-without-reinstall": "gulp clean && gulp release && npm run deploy-current",
     "deploy-current": "npm run get-deploy-overrides && gulp make-package --serverConfigOverride ./privateserverconfig.json --clientConfigOverride ./wwwroot/privateconfig.json && cd deploy/aws && ./stack create && cd ../.. && npm run sha256",
-    "get-deploy-overrides": "aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ServerConfigOverridePath ./privateserverconfig.json && aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ClientConfigOverridePath ./wwwroot/privateconfig.json"
+    "get-deploy-overrides": "aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ServerConfigOverridePath ./privateserverconfig.json && aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ClientConfigOverridePath ./wwwroot/privateconfig.json",
+    "release-catalog": "gulp release-catalog"
   },
   "husky": {
     "hooks": {

--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -1,6 +1,6 @@
 {
     "initializationUrls" : [
-        "proxy/_60s/http://static.nationalmap.nicta.com.au/investormap/init/now.json"
+        "proxy/_60s/http://static.nationalmap.nicta.com.au/investormap/init/2019-02-07.json"
     ],
     "parameters": {
         "feedbackUrl": "feedback",

--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -1,6 +1,6 @@
 {
     "initializationUrls" : [
-        "proxy/_60s/http://static.nationalmap.nicta.com.au/investormap/init/2019-02-07.json"
+        "proxy/_60s/http://static.nationalmap.nicta.com.au/investormap/init/now.json"
     ],
     "parameters": {
         "feedbackUrl": "feedback",


### PR DESCRIPTION
With this change, the whole release process becomes:

```sh
git clone https://github.com/TerriaJS/InvestorMap
cd InvestorMap

# Manual steps if it has been more than a week or two since the last release:

# Merge the latest changes from NationalMap into Investor Map. Commit and push these changes.
git remote add nm https://github.com/TerriaJS/NationalMap
git fetch nm
git merge nm/master

# There may be merge conflicts, particularly in package.json. Resolve these by hand, generally
# favouring HEAD (InvestorMap). 
# Then `git add` the files.
git commit
git push -u origin master

# Make sure we have the latest catalog
rm -rf node_modules/nationalmap-catalog && npm install

npm run release-catalog

npm run deploy
```

It does feel like annoyingly much code though.