### PR TITLE
Point to latest vector tile server instead of a specific version

### DIFF
--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -2468,7 +2468,7 @@
         },
         "TRA_2018": {
             "layerName": "Tourism_Regions_2018",
-            "server": "https://vector-tiles-2018-11-08.terria.io/Tourism_Regions_2018/{z}/{x}/{y}.pbf",
+            "server": "https://vector-tiles.terria.io/Tourism_Regions_2018/{z}/{x}/{y}.pbf",
             "serverType": "MVT",
             "serverMaxNativeZoom": 12,
             "serverMaxZoom": 28,


### PR DESCRIPTION
Tourism_Regions_2018 currently points to a specific version of vector tile server that we are taking down. Tourism_Regions_2018 layer also exists on the latest server, so point to the standard vector tile server address.